### PR TITLE
provide ability to turn on/off date range filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         </div>
         <div class="search-bar mg-container">
             <div class="mg-row mg-x--start">
-                <div class="mg-group grid-cel mg-x10" id="group-example" data-toggle="htmlpreview">
+                <div class="mg-group grid-cel mg-x10" id="group-example">
                     <div class="mg-dropdown" data-value="bmw" id="car-dropdown">
                       <button title="Sort and Filter" class="mg-button mg-button--small"
                             @click="SettingsShown = !SettingsShown">
@@ -44,7 +44,7 @@
             <div class="mg-container">
                 <div class="mg-row">
                     <div class="grid-cel mg-x2"><label for="currentSortOrder">Sort:</label></div>
-                    <div class="grid-cel mg-x6">
+                    <div class="grid-cel mg-x6 mg-select">
                         <select id="currentSortOrder" x-model.number="CurrentSortOrder">
                             <option value=1>By Date Descending</options>
                             <option value=2>By Date Ascending</options>
@@ -63,20 +63,34 @@
                     <div class="grid-cel mg-x2 filter-range-label">
                         <label for="showAfterDate">Show After:</label>
                     </div>
-                    <div class="grid-cel mg-x8">
-                        <input id="showAfterDate" type="date" x-model="FilterDateBegin">
+                    <div class="grid-cel mg-x2">
+                        <input id="showAfterDate" type="date" x-model="FilterDateBegin" :disabled="!BeginDateRangeFiltering">
+                    </div>
+                    <div class="grid-cel mg-x2">
+                        <label class="mg-toggle">
+                            On
+                            <input type="checkbox" checked="" x-model="BeginDateRangeFiltering">
+                            <span class="mg-toggle--icon"></span>
+                          </label>
                     </div>
                 </div>
                 <div class="mg-row">
                     <div class="grid-cel mg-x2 filter-range-label">
                         <label for="showBeforeDate">Show Before:</label>
                     </div>
-                    <div class="grid-cel mg-x8">
-                        <input id="showBeforeDate" type="date" x-model="FilterDateEnd">
+                    <div class="grid-cel mg-x2">
+                        <input id="showBeforeDate" type="date" x-model="FilterDateEnd" :disabled="!EndDateRangeFiltering">
+                    </div>
+                    <div class="grid-cel mg-x2">
+                        <label class="mg-toggle">
+                            On
+                            <input type="checkbox" checked="" x-model="EndDateRangeFiltering">
+                            <span class="mg-toggle--icon"></span>
+                        </label>
                     </div>
                 </div>
                 <div class="mg_row">
-                    <div class="mg-row" id="onlyShowActive" data-toggle="htmlpreview">
+                    <div class="mg-row" id="onlyShowActive">
                         <label class="mg-toggle">
                           Only show Active applications
                           <input type="checkbox" checked="" x-model="OnlyShowActive">
@@ -213,7 +227,7 @@
                     </div>
                 </div>
                 <div class="mg-row mg-m-display detail-buttons">
-                    <div class="mg-col mg-x4" data-toggle="htmlpreview">
+                    <div class="mg-col mg-x4">
                         <button class="mg-button mg-button--outline mg-collapse mg-icon-collapse"
                             data-toggle="collapse">Actions</button>
                         <div class="mg-collapse--content">

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -8,25 +8,32 @@ interface ISettings {
     ShowDateRangeBegin: string|null;
     ShowDateRangeEnd: string | null;
     OnlyShowActive: boolean | null;
+    DateRangeBeginFilteringOn: boolean;
+    DateRangeEndFilteringOn: boolean;
 }
 
 export default class Settings implements ISettings {
     DefaultSortOrder: SortOrder;
     CurrentSortOrder: SortOrder;
     ShowDateRangeBegin: string|null;
-    ShowDateRangeEnd: string|null;
+    ShowDateRangeEnd: string | null;
+    DateRangeBeginFilteringOn: boolean;
+    DateRangeEndFilteringOn: boolean;
     private origSettings: ISettings;
     public OnlyShowActive: boolean;
 
     constructor(defaultSortOrder: SortOrder = SortOrder.ActiveFirstDateDescending,
             showDateRangeBegin: string|null = "1970-01-01",
             showDateRangeEnd: string | null = dateToString(new Date()),
-            onlyShowActive:boolean = false) {
+            onlyShowActive: boolean = false, dateRangeBeginOn: boolean = false,
+            dateRangeEndOn: boolean = false) {
         this.DefaultSortOrder = defaultSortOrder;
         this.ShowDateRangeBegin = showDateRangeBegin;
         this.ShowDateRangeEnd = showDateRangeEnd;
         this.CurrentSortOrder = defaultSortOrder;
         this.OnlyShowActive = onlyShowActive;
+        this.DateRangeBeginFilteringOn = dateRangeBeginOn;
+        this.DateRangeEndFilteringOn = dateRangeEndOn;
         this.origSettings = this.Copy();
     }
 
@@ -38,7 +45,9 @@ export default class Settings implements ISettings {
         if (loadedSettingsString != null && loadedSettingsString.length > 0) {
             rawLoadedSettings = JSON.parse(loadedSettingsString);
             loadedSettings = new Settings(rawLoadedSettings.DefaultSortOrder, rawLoadedSettings.ShowDateRangeBegin || null,
-                rawLoadedSettings.ShowDateRangeEnd, rawLoadedSettings.OnlyShowActive
+                rawLoadedSettings.ShowDateRangeEnd, rawLoadedSettings.OnlyShowActive,
+                rawLoadedSettings.DateRangeBeginFilteringOn,
+                rawLoadedSettings.DateRangeEndFilteringOn
             );
         }
 
@@ -56,8 +65,12 @@ export default class Settings implements ISettings {
             isDirty = true;
         } else if (this.OnlyShowActive != this.origSettings.OnlyShowActive) {
             isDirty = true;
+        } else if (this.DateRangeBeginFilteringOn != this.origSettings.DateRangeBeginFilteringOn) {
+            isDirty = true;
+        } else if (this.DateRangeEndFilteringOn != this.origSettings.DateRangeEndFilteringOn) {
+            isDirty = true;
         }
-
+        
         return isDirty;
     }
 
@@ -75,7 +88,9 @@ export default class Settings implements ISettings {
             DefaultSortOrder: this.DefaultSortOrder,
             ShowDateRangeBegin: this.ShowDateRangeBegin,
             ShowDateRangeEnd: this.ShowDateRangeEnd,
-            OnlyShowActive: this.OnlyShowActive
+            OnlyShowActive: this.OnlyShowActive,
+            DateRangeBeginFilteringOn: this.DateRangeBeginFilteringOn,
+            DateRangeEndFilteringOn: this.DateRangeEndFilteringOn
         }
     }
 
@@ -84,7 +99,9 @@ export default class Settings implements ISettings {
             DefaultSortOrder: this.DefaultSortOrder,
             ShowDateRangeBegin: this.ShowDateRangeBegin,
             ShowDateRangeEnd: this.ShowDateRangeEnd,
-            OnlyShowActive: this.OnlyShowActive
+            OnlyShowActive: this.OnlyShowActive,
+            DateRangeBeginFilteringOn: this.DateRangeBeginFilteringOn,
+            DateRangeEndFilteringOn: this.DateRangeEndFilteringOn
         }
 
         return copy;
@@ -95,6 +112,8 @@ export default class Settings implements ISettings {
         this.ShowDateRangeBegin = this.origSettings.ShowDateRangeBegin;
         this.ShowDateRangeEnd = this.origSettings.ShowDateRangeEnd;
         this.OnlyShowActive = this.origSettings.OnlyShowActive || false;
+        this.DateRangeBeginFilteringOn = this.origSettings.DateRangeBeginFilteringOn;
+        this.DateRangeEndFilteringOn = this.origSettings.DateRangeEndFilteringOn
     }
 
     get DefaultStartDate(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,7 +183,11 @@ class JobSearchViewModel {
                 include = false;
             }
 
-            if (include && row.StartDate.Data < startDate || row.StartDate.Data > endDate) {
+            if (include && this.Settings.DateRangeBeginFilteringOn && row.StartDate.Data < startDate) {
+                include = false;
+            }
+
+            if (include && this.Settings.DateRangeEndFilteringOn && row.StartDate.Data > endDate) {
                 include = false;
             }
 
@@ -317,6 +321,24 @@ class JobSearchViewModel {
 
     set OnlyShowActive(newValue: boolean) {
         this.Settings.OnlyShowActive = newValue;
+        this.populateCurrentView();
+    }
+
+    get BeginDateRangeFiltering(): boolean {
+        return this.Settings.DateRangeBeginFilteringOn;
+    }
+
+    set BeginDateRangeFiltering(newValue: boolean) {
+        this.Settings.DateRangeBeginFilteringOn = newValue;
+        this.populateCurrentView();
+    }
+
+    get EndDateRangeFiltering(): boolean {
+        return this.Settings.DateRangeEndFilteringOn;
+    }
+
+    set EndDateRangeFiltering(newValue: boolean) {
+        this.Settings.DateRangeEndFilteringOn = newValue;
         this.populateCurrentView();
     }
 }


### PR DESCRIPTION
It occurred to me that filtering by date range is probably not a primary use case, while having it always on caused a problem: unless you updated the date range end every day or set it into the far future, your new jobs would not appear in the view.

Now, that kind of filtering is turned off by default.