### PR TITLE
Add app counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,14 @@
                 </div>
             </div>
         </div>
+        <div class="mg-container mg-s-hidden">
+            <span x-text="TotalRowCount"></span>
+            <span> total job applications, of which </span>
+            <span x-text="ActiveRowCount"></span>
+            <span> are active; </span>
+            <span x-text="RowsInViewCount"></span>
+            <span> are currenlty displayed</span>
+        </div>
         <div class="summary-page" x-show="!DetailsShown" x-transition.duration.100ms>
             <div x-show="IsEmpty()">
                 <h2>No job search activities have been added yet.</h2>

--- a/src/main.ts
+++ b/src/main.ts
@@ -482,6 +482,25 @@ class JobSearchViewModel {
             this.importFormatError = false;
         }
     }
+
+    get TotalRowCount(): number {
+        return this.JobSearchData.length;
+    }
+
+    get ActiveRowCount(): number {
+        let activeRowCount = 0;
+        this.JobSearchData.forEach((a) => {
+            if (a.Open) {
+                ++activeRowCount;
+            }
+        });
+            
+        return activeRowCount; 
+    }
+
+    get RowsInViewCount(): number {
+        return this.CurrentView.length;
+    }
 }
 
 Alpine.store('jobsearchdata', new JobSearchViewModel());

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,7 @@ class JobSearchViewModel {
 
         // After persisting, sort so that any new rows appear where they should
         this.sortView(this.CurrentSortOrder);
+        this.populateCurrentView();
     }
 
     public Revert(): void {


### PR DESCRIPTION
Add a line of statistical information just below the search area. It displays the total number of job applications, the number that are Active and the number that are shown in the current view.